### PR TITLE
cicd: moved poetry files into seperate copy to leverage docker cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,15 @@ ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH=/app
 
 WORKDIR /app
-COPY . /app
+# copying poetry stuff before the rest of the code to take advantage of docker caching
+# COPY poetry.lock .
+COPY pyproject.toml .
 
 RUN poetry config virtualenvs.create false \
   && poetry install --only main
+
+COPY . /app
+
 
 EXPOSE 8000
 

--- a/Dockerfile-redis
+++ b/Dockerfile-redis
@@ -14,10 +14,15 @@ ENV PYTHONUNBUFFERED=1
 ENV PYTHONPATH=/app
 
 WORKDIR /app
-COPY . /app
+# copying poetry stuff before the rest of the code to take advantage of docker caching
+# COPY poetry.lock .
+COPY pyproject.toml .
 
 RUN poetry config virtualenvs.create false \
   && poetry install --only main
+
+COPY . /app
+
 
 EXPOSE 8000
 


### PR DESCRIPTION
Copying toml file before the whole app enables the poetry environment build to be cached.

So it will only redo that step if toml file contents change.