### PR TITLE
fix: do not return false on errors, throw exceptions

### DIFF
--- a/app/core/redis.py
+++ b/app/core/redis.py
@@ -46,6 +46,7 @@ def redis_listener(redis_conn):
                         except Exception as e:
                             logger.debug(
                                 f"File {file} could not be downloaded. Probably not part of a storage account.")
+                            raise e
                 stac = STACItemCreator(item_dict).create_item()
                 logger.info(f"Created STAC item")
 
@@ -70,7 +71,7 @@ def redis_listener(redis_conn):
                         logger.info("Published to STAC API")
                     except Exception as e:
                         logger.error(f"Error publishing to STAC API: {e}")
-                        break
+                        raise e
                 if _CLEANUP_DOWNLOADED_FILES:
                     files_to_delete = item_dict.get("files_converted_to_cog", []) + item_dict.get("discovered_files",
                                                                                                   []) + item_dict.get(
@@ -90,7 +91,7 @@ def redis_listener(redis_conn):
 
         except redis.ConnectionError as e:
             logger.error(f"Redis connection error: {e}")
-            break
+            raise e
 
         # not catching this makes it eaiser to debug, as this exception is raised any of the functions and in the try
         # block fail subfunctions in the try block fail except Exception as e: logger.error(f"Error processing item:


### PR DESCRIPTION
Nothing to be done, just a quick one for learning experience.

It is always a bad idea to return false if there are erros.
Notice how code before was either returning false if the upload operation does not succeed, or url if it does.

Now you have two different types of value. It is much better to raise exeptions when something goes wrong and then catch them yourself in the code which is calling that function. 

Do you want to terminate the code, or maybe just log it? - it all comes down to the code which is calling the function, not that function itself.

Clean code book, page 46